### PR TITLE
Update styles.php

### DIFF
--- a/styles.php
+++ b/styles.php
@@ -35,4 +35,8 @@ if (!$userconfig) {
     exit;
 }
 
-echo "body.accessibility-backgroundcolour, body.accessibility-backgroundcolour *:not(.mediaplugin, .mediaplugin *) { background-color: {$userconfig} !important; }";
+echo <<<EOL
+body.accessibility-backgroundcolour, body.accessibility-backgroundcolour *:not(.mediaplugin, .mediaplugin *) {
+    background-color: {$userconfig} !important;
+}
+EOL;

--- a/styles.php
+++ b/styles.php
@@ -35,4 +35,4 @@ if (!$userconfig) {
     exit;
 }
 
-echo "body.accessibility-backgroundcolour, body.accessibility-backgroundcolour * { background-color: {$userconfig}; }";
+echo "body.accessibility-backgroundcolour, body.accessibility-backgroundcolour * { background-color: {$userconfig} !important; }";

--- a/styles.php
+++ b/styles.php
@@ -35,4 +35,4 @@ if (!$userconfig) {
     exit;
 }
 
-echo "body.accessibility-backgroundcolour, body.accessibility-backgroundcolour * { background-color: {$userconfig} !important; }";
+echo "body.accessibility-backgroundcolour, body.accessibility-backgroundcolour *:not(.mediaplugin, .mediaplugin *) { background-color: {$userconfig} !important; }";


### PR DESCRIPTION
Noticed that some styles in Moodle (in particular the navbar) uses the !important tag for .bg-white. To override this, and prevent the navbar looking only half-painted, I've added !important to the style in styles.php.